### PR TITLE
sizeThatFits has to be invoked on the main thread

### DIFF
--- a/ios/RNTweetShadowView.m
+++ b/ios/RNTweetShadowView.m
@@ -4,7 +4,7 @@
 
 - (TWTRTweetView *)tweetViewForMeasuring
 {
-    static TWTRTweetView *tweetView = nil;;
+    static TWTRTweetView *tweetView = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         tweetView = [[TWTRTweetView alloc] initWithTweet:nil style:TWTRTweetViewStyleCompact];
@@ -12,15 +12,16 @@
     return tweetView;
 }
 
-
 - (CGSize)computeIntrinsicSize:(CGFloat)width
 {
     static CGSize defaultSize;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        TWTRTweetView *view = [self tweetViewForMeasuring];
-        defaultSize = [view sizeThatFits:CGSizeMake(width, CGFLOAT_MAX)]; // 200 is the minimum width required for a tweet
-        defaultSize.width = UIViewNoIntrinsicMetric;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            TWTRTweetView *view = [self tweetViewForMeasuring];
+            defaultSize = [view sizeThatFits:CGSizeMake(width, CGFLOAT_MAX)]; // 200 is the minimum width required for a tweet
+            defaultSize.width = UIViewNoIntrinsicMetric;
+        });        
     });
     
     return defaultSize;

--- a/ios/RNTwitterKitViewManager.m
+++ b/ios/RNTwitterKitViewManager.m
@@ -8,6 +8,12 @@
 
 @implementation RNTwitterKitViewManager
 
+// this module is supposed to run in the main queue
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_main_queue();
+}
+
 RCT_EXPORT_MODULE(TweetView);
 RCT_REMAP_VIEW_PROPERTY(tweetid, TWEETID, NSString);
 RCT_REMAP_VIEW_PROPERTY(showActionButtons, SHOWACTIONBUTTONS, BOOL);
@@ -21,18 +27,13 @@ RCT_REMAP_VIEW_PROPERTY(backgroundColor, BACKGROUNDCOLOR, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(onLoadSuccess, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onLoadError, RCTBubblingEventBlock)
 
-@synthesize bridge = _bridge;
-
 - (UIView *)view
 {
     RNTwitterKitView *view = [[RNTwitterKitView alloc] init];
     view.delegate = self;
     view.twitterAPIClient = [self twitterAPIClient];
-    
     return view;
 }
-
-
 
 - (RCTShadowView *)shadowView
 {
@@ -41,13 +42,11 @@ RCT_EXPORT_VIEW_PROPERTY(onLoadError, RCTBubblingEventBlock)
 
 - (void)tweetView:(RNTwitterKitView *)view requestsResize:(CGSize)newSize
 {
-    
     //getting the tweet view
     UIView *tweetView = view;
     
     //create a new size fot the tweet view
     CGSize newTweetViewSize = newSize;
-    
     
     NSLog(@"new tweet size: %f,%f", newTweetViewSize.width, newTweetViewSize.height);
     //getting the UI manager and set the intrinsic content size of the tweet view


### PR DESCRIPTION
- method RNTweetShadowView.computeIntrinsicSize has to make sure, that sizeThatFits gets invoked in the main thread.  
- _bridge property removed. Shadows native implementation.  
- (dispatch_queue_t)methodQueue added to RNTwitterKitViewManager, since this module is supposed to run in main queue  
