### PR TITLE
Add dependencies for TwitterCore and TwitterKit stable verions

### DIFF
--- a/ReactNativeTwitterKit.podspec
+++ b/ReactNativeTwitterKit.podspec
@@ -22,7 +22,8 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
   s.dependency "Fabric"
-  s.dependency "TwitterKit"
+  s.dependency "TwitterCore", "3.0.3"
+  s.dependency "TwitterKit", "3.2.2"
 
   # For now, we are going with static libararies (default); the following
   # stays commented out, in case we need it


### PR DESCRIPTION
Fix the versions for TwitterCore and TwitterKit in order to have stable working visions. The last once have braking changes and we do not always have control over it. 